### PR TITLE
Fix BACKSPACE underflow bug

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -61,7 +61,7 @@ String read_line(void) {
             case BACKSPACE:
                 printf("\b \b");
                 fflush(NULL);
-                buffer.len--;
+                if(buffer.len > 0) buffer.len--;
                 break;
             default:
                 buffer.chars[buffer.len++] = (char)c;


### PR DESCRIPTION
# Buffer Underflow leading to double free memory error and program crashing :

# Trigger
=> running the shell 
=> pressing BACKSPACE on empty string
=> pressing CTRL+c 
=> pressing ENTER

# Code snippet causing the error 

```
String read_line(void) {
            ........
            ........
            case BACKSPACE:
                printf("\b \b");
                fflush(NULL);
                buffer.len--; // THIS LINE 64
                break;
```

# Fix : Adding Bound check using if statement

```
 if (buffer.len > 0) buffer.len--;

```

# Terminal Emulator behavior

## Alacritty

*program crashes with the following error message*

```
double free or corruption (out)
zsh: IOT instruction (core dumped)

```
## Xterm
*Does not crash on Xterm*

# How the fix works
It checks the length of the buffer before decrementing its length *buffer.len* which prevents the underflow which prevents the double free error.